### PR TITLE
vim: MySQL upgrades

### DIFF
--- a/home/.vim/config/bundles
+++ b/home/.vim/config/bundles
@@ -73,8 +73,10 @@ Bundle 'hail2u/vim-css3-syntax'
 Bundle 'tpope/vim-rails'
 
 " SQL
-Bundle 'vim-scripts/SQLUtilities'
 Bundle 'vim-scripts/Align'
+Bundle 'NLKNguyen/pipe-mysql.vim'
+Bundle 'NLKNguyen/pipe.vim'
+Bundle 'smintz/vim-sqlutil'
 
 " Go
 Bundle 'fatih/vim-go'

--- a/home/.vim/config/environment
+++ b/home/.vim/config/environment
@@ -81,6 +81,8 @@ let g:syntastic_always_populate_loc_list = 1
 let g:loaded_AlignMapsPlugin = 0
 let g:sqlutil_keyword_case = '\U'
 
+autocmd FileType sql,mysql set commentstring=--\ %s
+
 let g:markdown_fenced_languages = ['coffee', 'css', 'erb=eruby', 'javascript', 'js=javascript', 'json=javascript', 'ruby', 'sass', 'xml', 'php']
 
 " PIV

--- a/home/.vim/config/mappings
+++ b/home/.vim/config/mappings
@@ -97,6 +97,10 @@ let g:multi_cursor_exit_from_insert_mode=0
 " PHP
 autocmd FileType php nmap <leader>pcf :call PhpCsFixerFixFile()<CR>
 
+" SQL
+autocmd FileType sql,mysql vmap <leader>fr :SQLUFormatter<CR>
+autocmd FileType sql,mysql nmap <leader>fr :SQLUFormatter<CR>
+
 " JSON
 nmap <leader>fj <Esc>:%!python -m json.tool<CR><Esc>:set filetype=json<CR>
 


### PR DESCRIPTION
This commit adds the ability to run mysql commands in vim. In addition,
there is a new mapping (<leader>fr) to format mysql queries.