### PR TITLE
vim: Replace PIV plugin

### DIFF
--- a/home/.vim/config/bundles
+++ b/home/.vim/config/bundles
@@ -48,7 +48,10 @@ if executable('ctags')
 endif
 
 " PHP
-Bundle 'spf13/PIV'
+Bundle 'tobyS/pdv'
+Bundle 'tobyS/vmustache'
+Bundle 'SirVer/ultisnips'
+Bundle 'alvan/vim-php-manual'
 Bundle 'stephpy/vim-php-cs-fixer'
 Bundle 'beyondwords/vim-twig'
 

--- a/home/.vim/config/mappings
+++ b/home/.vim/config/mappings
@@ -100,6 +100,8 @@ let g:multi_cursor_exit_from_visual_mode=0
 let g:multi_cursor_exit_from_insert_mode=0
 
 " PHP
+let g:pdv_template_dir = $HOME."/.vim/bundle/pdv/templates_snip"
+autocmd FileType php noremap <leader>pd :call pdv#DocumentWithSnip()<CR>
 autocmd FileType php nmap <leader>pcf :call PhpCsFixerFixFile()<CR>
 
 " SQL


### PR DESCRIPTION
This replaces PIV with pdv which for the most part does the same thing
but without all of the bugs with moving around, commenting, etc.

Also added is vim-php-manual to replace PIV's <K> functionality.