### PR TITLE
vim: fix <C-h> mapping

### DIFF
--- a/home/.vim/config/environment
+++ b/home/.vim/config/environment
@@ -110,6 +110,7 @@ set tags=./tags;/,~/.vimtags
 
 autocmd BufNewFile,BufRead fugitive://* set bufhidden=delete
 autocmd FileType php set tabstop=4|set shiftwidth=4
+let g:php_manual_online_search_shortcut = '<leader>K'
 
 autocmd FileType * autocmd CursorMovedI,InsertLeave * call ClosePreviewWindow()
 autocmd FileType mysql let b:noClosePreview=1


### PR DESCRIPTION
The new php commenting plugin had <C-h> mapped to open the online
documentation. This reconfigures the mapping to <leader>K (K being the
offline).