### PR TITLE
osx issue; check if dircolors exists before calling dircolors

### DIFF
--- a/home/.zsh/environment.zsh
+++ b/home/.zsh/environment.zsh
@@ -5,7 +5,9 @@ export TERM=xterm-256color
 
 export FZF_CTRL_R_OPTS="--inline-info --exact"
 
-eval "$(dircolors ~/.dircolors)"
+if whence dircolors >/dev/null; then
+    eval "$(dircolors ~/.dircolors)"
+fi
 
 [ -e "$HOME/Projects/golang" ] && export GOPATH="$HOME/Projects/golang"
 [ -e "/usr/local/go" ] && export PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"

--- a/home/.zsh/environment.zsh
+++ b/home/.zsh/environment.zsh
@@ -5,9 +5,7 @@ export TERM=xterm-256color
 
 export FZF_CTRL_R_OPTS="--inline-info --exact"
 
-if whence dircolors >/dev/null; then
-    eval "$(dircolors ~/.dircolors)"
-fi
+command -v dircolors > /dev/null && dircolors ~/.dircolors
 
 [ -e "$HOME/Projects/golang" ] && export GOPATH="$HOME/Projects/golang"
 [ -e "/usr/local/go" ] && export PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"

--- a/home/.zsh/environment.zsh
+++ b/home/.zsh/environment.zsh
@@ -5,7 +5,7 @@ export TERM=xterm-256color
 
 export FZF_CTRL_R_OPTS="--inline-info --exact"
 
-command -v dircolors > /dev/null && dircolors ~/.dircolors
+command -v dircolors > /dev/null && eval "$(dircolors ~/.dircolors)"
 
 [ -e "$HOME/Projects/golang" ] && export GOPATH="$HOME/Projects/golang"
 [ -e "/usr/local/go" ] && export PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"


### PR DESCRIPTION
OSX doesn't support dircolors so you get an error every time you open a new terminal. This just checks if dircolors is there and only runs the `eval` if is.