### PR TITLE
zsh: Fix empty package.json version

### DIFF
--- a/home/.zsh/themes/spaceship.zsh
+++ b/home/.zsh/themes/spaceship.zsh
@@ -589,6 +589,9 @@ spaceship_package() {
 
   # Grep and cut out package version
   local package_version=$(grep '"version":' package.json | cut -d\" -f4 2> /dev/null)
+
+  [[ -z "$package_version" ]] && return
+
   package_version="v${package_version}"
 
   _prompt_section \


### PR DESCRIPTION
This function checks for the existence of a package.json file and then
assumes a version is also set. This isn't always the case and thus we
end up with a prompt component that simply says "v". This prevents that
issue from occurring.