### PR TITLE
docker: Convert messy aliases to functions

### DIFF
--- a/home/.zsh/aliases.zsh
+++ b/home/.zsh/aliases.zsh
@@ -47,29 +47,8 @@ alias gsta='gst apply'
 alias gsts='gst save'
 alias gstsu='gsts -u'
 
-alias dkr-build='dkr-down && docker-compose rm -f && docker rmi $(echo "${${PWD##*/}/./}_app" | sed "s/[^a-zA-Z0-9_]//g"); docker-compose build && dkr-up'
-alias dkr-down="docker-compose stop"
 alias dkr-exec='docker exec -it --detach-keys "ctrl-q,q" '
-alias dkr-logs="docker-compose logs -f"
-alias dkr-reup="dkr-down && dkr-up"
+alias dkr-run='docker run -it --detach-keys "ctrl-q,q" '
 alias dkr-stats="docker stats \$(docker ps --format '{{.Names}}')"
-alias dkr-up="docker-compose up -d && dkr-logs"
-alias dkr-update="docker images | awk '{print \$1}' | xargs -L1 docker pull"
-alias dkr-mysql="dkr-exec \$(docker-compose ps -q mysql) mysql"
-
-alias dkr-proxy="docker stop proxy && docker rm proxy; docker run --name proxy -d -p 80:80 -v /var/run/docker.sock:/tmp/docker.sock -v ~/.nginx.prof.conf:/etc/nginx/conf.d/proxy.conf:ro --net bridge -it jwilder/nginx-proxy"
-alias dkr-nginx-proxy="docker stop proxy && docker rm proxy; docker pull jwilder/nginx-proxy && docker run --name proxy -d -p 80:80 -p 443:443 -v /var/run/docker.sock:/tmp/docker.sock:ro -v ~/.config/nginx-proxy/html:/usr/share/nginx/html:rw -v ~/.config/nginx-proxy/proxy.conf:/etc/nginx/conf.d/proxy.conf:ro -v ~/.config/nginx-proxy/vhost.d/:/etc/nginx/vhost.d:rw -v ~/.config/nginx-proxy/htpasswd/:/etc/nginx/htpasswd:ro -v ~/.config/nginx-proxy/certs:/etc/nginx/certs:ro --log-opt max-size=1M --net bridge --label com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy=true jwilder/nginx-proxy"
-alias dkr-ssl="docker stop ssl && docker rm ssl; docker pull jrcs/letsencrypt-nginx-proxy-companion && docker run --name ssl -d -v /var/run/docker.sock:/var/run/docker.sock:ro -v ~/.config/nginx-proxy/certs:/etc/nginx/certs:rw --volumes-from proxy jrcs/letsencrypt-nginx-proxy-companion"
-alias dkr-proxy="dkr-nginx-proxy && dkr-ssl"
-
-alias nvidia-dkr-logs="nvidia-docker-compose logs -f | grep -iE --color=auto '(exception|fatal|error|warning|info|trigger_error)|$'"
-alias nvidia-dkr-exec='nvidia-docker exec -it --detach-keys "ctrl-q,q" '
-alias nvidia-dkr-run='nvidia-docker run -it --detach-keys "ctrl-q,q" '
-alias nvidia-dkr-up="nvidia-docker-compose pull && nvidia-docker-compose up -d --remove-orphans && dkr-logs"
-alias nvidia-dkr-down="nvidia-docker-compose stop"
-alias nvidia-dkr-reup="nvidia-dkr-down && dkr-up"
-alias nvidia-dkr-build='nvidia-dkr-down && nvidia-docker-compose rm && nvidia-docker rmi $(echo "${${PWD##*/}/./}_app" | sed "s/[^a-zA-Z0-9_]//g"); nvidia-docker-compose build --no-cache && nvidia-dkr-up'
-alias nvidia-dkr-stats="nvidia-docker stats \$(nvidia-docker ps --format '{{.Names}}')"
-alias nvidia-dkr-update="nvidia-docker images | awk '{print \$1}' | xargs -L1 nvidia-docker pull"
 
 [ -e ~/.aliases.local ] && . ~/.aliases.local || true

--- a/home/.zsh/functions.zsh
+++ b/home/.zsh/functions.zsh
@@ -1,10 +1,10 @@
 # Convenient function to allow local overrides for all sourced files
-function load_file() {
+function load_file {
     [ -e ~/.zsh/${1} ] && . ~/.zsh/${1} || true
     [ -e ~/.zsh.local/${1} ] && . ~/.zsh.local/${1} || true
 }
 
-man() {
+function man {
     env \
         LESS_TERMCAP_mb=$(printf "\e[1;31m") \
         LESS_TERMCAP_md=$(printf "\e[1;31m") \
@@ -16,16 +16,4 @@ man() {
         man "$@"
 }
 
-function dkr-bash {
-    dir="${PWD##*/}"
-    dir="${dir/./}"
-    container=$(echo "${dir}_app_1" | sed "s/[^[:alpha:]^[:digit:]_]//")
-    docker exec -it --detach-keys 'ctrl-q,q' "${container}" bash
-}
-
-function dkr-zsh {
-    dir="${PWD##*/}"
-    dir="${dir/./}"
-    container=$(echo "${dir}" | sed "s/[^[:alpha:][:digit:]_]//g")
-    docker exec -it --detach-keys 'ctrl-q,q' "${container}_app_1" zsh
-}
+. ~/.zsh/functions/docker.zsh

--- a/home/.zsh/functions/docker.zsh
+++ b/home/.zsh/functions/docker.zsh
@@ -1,0 +1,87 @@
+function dkr-container-name {
+    local dir="${PWD##*/}"
+    dir="${dir/./}"
+
+    local app=${1:-app}
+    __container="$(echo "${dir}" | sed "s/[^a-zA-Z0-9]//")_${app}"
+}
+
+function dkr-down {
+    docker-compose stop $1
+}
+
+function dkr-up {
+    docker-compose up --remove-orphans -d $1 && \
+        dkr-logs $1
+}
+
+function dkr-bash {
+    dkr-container-name ${1}
+
+    dkr-exec "${__container}_1" bash
+}
+
+function dkr-zsh {
+    dkr-container-name ${1}
+
+    dkr-exec "${__container}_1" zsh
+}
+
+function dkr-logs {
+    docker-compose logs -f --tail ${2:-100} $1 | grep -iE --color=auto '(exception|fatal|error|warning|info|trigger_error)|$'
+}
+
+function dkr-reup {
+    read -q "reply?Are you sure you'd like to restart ${1:-everything}? "
+    echo
+
+    if [[ $reply =~ ^[Yy]$ ]]
+    then
+        dkr-down $1 && dkr-up $1
+    else
+        echo "Aborting!"
+    fi
+}
+
+function dkr-clean {
+    dkr-container-name ${1}
+
+    dkr-down $1 && \
+        docker-compose rm -f $1 && \
+        docker rmi "${__container}"
+}
+
+function dkr-proxy {
+    mkdir -p ~/.config/nginx-proxy/{html,vhost.d,htpasswd,certs}
+    touch ~/.config/nginx-proxy/proxy.conf
+
+    docker stop proxy && \
+        docker rm proxy
+
+    docker pull jwilder/nginx-proxy && \
+        dkr-run --name proxy -d \
+            -p 80:80 \
+            -p 443:443 \
+            -v /var/run/docker.sock:/tmp/docker.sock:ro \
+            -v ~/.config/nginx-proxy/html:/usr/share/nginx/html:rw \
+            -v ~/.config/nginx-proxy/proxy.conf:/etc/nginx/conf.d/custom-proxy.conf:ro \
+            -v ~/.config/nginx-proxy/vhost.d/:/etc/nginx/vhost.d:rw \
+            -v ~/.config/nginx-proxy/htpasswd/:/etc/nginx/htpasswd:ro \
+            -v ~/.config/nginx-proxy/certs:/etc/nginx/certs:ro \
+            --log-opt max-size=5M \
+            --net bridge \
+            --label com.github.jrcs.letsencrypt_nginx_proxy_companion.nginx_proxy=true \
+            jwilder/nginx-proxy
+
+    docker stop ssl && \
+        docker rm ssl
+
+    docker pull jrcs/letsencrypt-nginx-proxy-companion && \
+        dkr-run --name ssl -d \
+            -e "ACME_CA_URI=https://acme-v01.api.letsencrypt.org/directory" \
+            -v /var/run/docker.sock:/var/run/docker.sock:ro \
+            -v ~/.config/nginx-proxy/certs:/etc/nginx/certs:rw \
+            --volumes-from proxy \
+            jrcs/letsencrypt-nginx-proxy-companion
+}
+

--- a/home/.zshrc
+++ b/home/.zshrc
@@ -2,13 +2,13 @@
 
 . ~/.zsh/git.zsh
 . ~/.zsh/themes/spaceship.zsh
+load_file "aliases.zsh"
 load_file "functions.zsh"
 load_file "environment.zsh"
 load_file "setopt.zsh"
 load_file "exports.zsh"
 load_file "completion.zsh"
 load_file "bindkeys.zsh"
-load_file "aliases.zsh"
 load_file "history.zsh"
 
 [ -e ~/.zshrc.local ] && . ~/.zshrc.local || true


### PR DESCRIPTION
This commit cleans up the docker aliases by converting most of them to
functions which allows us to target specific containers within a
docker-compose application instead of always targeting the whole setup.
In addition, we've created a functions directory to house related
functions that are sourced by functions.zsh.

To be able to use the aliases inside functions.zsh, I had to modify
.zshrc to source aliases before functions.