### PR TITLE
tmux: Add tl alias

### DIFF
--- a/home/.zsh/aliases.zsh
+++ b/home/.zsh/aliases.zsh
@@ -3,6 +3,7 @@ alias l="ls -lhF"
 alias ll="ls -alhF"
 alias homesick="~/.homeshick"
 alias tmux='tmux -2 -u'
+alias tl='tmux list-sessions'
 alias e='emacsclient -t'
 alias E="SUDO_EDITOR=\"emacsclient -t -a emacs\" sudoedit"
 


### PR DESCRIPTION
This alias is a very quick means of seeing which sessions exist on a
server. It's one of the first commands I run when I ssh into a server as
my memory doesn't allow me to remember what I've left running!