### PR TITLE
README: Follow Shortened url

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ $ curl -o- https://raw.githubusercontent.com/keelerm84/dotfiles/master/install.s
 
 Shortened url:
 ```bash
-$ curl -o- http://bit.ly/2pztvLf | bash
+$ curl -Lo- http://bit.ly/2pztvLf | bash
 ```


### PR DESCRIPTION
The readme's command to use the bash script with a bit.ly url is missing
the -L to follow redirects. Now we don't have to use the long url
anymore!