### PR TITLE
docker: make helper functions smarter

### DIFF
--- a/home/.zsh/aliases.zsh
+++ b/home/.zsh/aliases.zsh
@@ -48,8 +48,4 @@ alias gsta='gst apply'
 alias gsts='gst save'
 alias gstsu='gsts -u'
 
-alias dkr-exec='docker exec -e COLUMNS="`tput cols`" -e LINES="`tput lines`" -it --detach-keys "ctrl-q,q" '
-alias dkr-run='docker run -it --detach-keys "ctrl-q,q" '
-alias dkr-stats="docker stats \$(docker ps --format '{{.Names}}')"
-
 [ -e ~/.aliases.local ] && . ~/.aliases.local || true

--- a/home/.zsh/functions/docker.zsh
+++ b/home/.zsh/functions/docker.zsh
@@ -32,7 +32,7 @@ function dkr-exec {
     local cmd="docker"
     local it="-it"
     local detachKeys=(--detach-keys "ctrl-q,q")
-    if [[ $__is_compose ]]; then
+    if [[ $__is_compose == true ]]; then
         cmd="docker-compose"
         it=""
         detachKeys=""
@@ -48,7 +48,7 @@ function dkr-run {
     local cmd="docker"
     local it="-it"
     local detachKeys=(--detach-keys "ctrl-q,q")
-    if [[ $__is_compose ]]; then
+    if [[ $__is_compose == true ]]; then
         cmd="docker-compose"
         it=""
         detachKeys=""
@@ -107,7 +107,7 @@ function dkr-logs {
     dkr-container-name $@
 
     local cmd="docker"
-    if [[ $__is_compose ]]; then
+    if [[ $__is_compose == true ]]; then
         cmd="docker-compose"
     fi
 

--- a/home/.zsh/functions/docker.zsh
+++ b/home/.zsh/functions/docker.zsh
@@ -1,9 +1,81 @@
 function dkr-container-name {
-    local dir="${PWD##*/}"
-    dir="${dir/./}"
+    __params=(${@[@]})
 
-    local app=${1:-app}
-    __container="$(echo "${dir}")_${app}"
+    # extract the container name
+    for __var in "$@"; do
+        if [[ $__var != \-* ]]; then
+            __container="$__var"
+            break
+        fi
+    done
+
+    # Replace the container name with the original if not a docker-compose project
+    if [[ -f ./docker-compose.yml && "$__var" == "" ]]; then
+        __is_compose=true
+    elif [[ ! -f ./docker-compose.yml || "$(docker-compose ps | grep $__var)" == "" ]]; then
+        __container="$__var"
+    else
+        __is_compose=true
+    fi
+
+    # Swap out the container name from the copy
+    for ((i=0; i < ${#__params[@]}; ++i)); do
+        if [[ "${__params[$i]}" == "$__var" ]]; then
+            __params[$i]="$__container"
+        fi
+    done
+}
+
+function dkr-exec {
+    dkr-container-name $@
+
+    local cmd="docker"
+    local it="-it"
+    local detachKeys=(--detach-keys "ctrl-q,q")
+    if [[ $__is_compose ]]; then
+        cmd="docker-compose"
+        it=""
+        detachKeys=""
+    fi
+
+    echo "Running: ${cmd} exec -e COLUMNS=\"`tput cols`\" -e LINES=\"`tput lines`\" ${detachKeys[@]} ${it} ${__params[@]}"
+    ${cmd} exec -e COLUMNS="`tput cols`" -e LINES="`tput lines`" ${detachKeys[@]} ${it} ${__params[@]}
+}
+
+function dkr-run {
+    dkr-container-name $@
+
+    local cmd="docker"
+    local it="-it"
+    local detachKeys=(--detach-keys "ctrl-q,q")
+    if [[ $__is_compose ]]; then
+        cmd="docker-compose"
+        it=""
+        detachKeys=""
+    fi
+
+    echo "Running: ${cmd} run -e COLUMNS=\"`tput cols`\" -e LINES=\"`tput lines`\" ${detachKeys[@]} ${it} ${__params[@]}"
+    ${cmd} run -e COLUMNS="`tput cols`" -e LINES="`tput lines`" ${detachKeys[@]} ${it} ${__params[@]}
+}
+
+function dkr-stats {
+    if [[ "$1" != "" ]]; then
+        dkr-container-name $1
+    fi
+
+    __containers="$1"
+
+    # If inside a docker-compose project
+    if [[ -z $__container || "$(docker ps | grep $__container)" != "" ]]; then
+        __containers="${__container}"
+    fi
+
+    # If not inside a docker-compose project and no container is requested, use all
+    if [[ "$__containers" == "" ]]; then
+        __containers="$(docker ps --format '{{.Names}}')"
+    fi
+
+    docker stats $(echo "$__containers")
 }
 
 function dkr-down {
@@ -16,23 +88,31 @@ function dkr-up {
 }
 
 function dkr-bash {
-    dkr-container-name ${1}
-
-    dkr-exec "${__container}_1" bash
+    dkr-exec "$1" bash
 }
 
 function dkr-zsh {
-    dkr-container-name ${1}
+    if [[ -z $1 ]]; then
+        1=app
+    fi
 
-    dkr-exec "${__container}_1" zsh
+    dkr-exec "$1" zsh
 }
 
 function dkr-logs {
-    docker-compose logs -f --tail ${2:-100} $1 | grep -iE --color=auto '(exception|fatal|error|warning|info|trigger_error)|$'
+    dkr-container-name $@
+
+    local cmd="docker"
+    if [[ $__is_compose ]]; then
+        cmd="docker-compose"
+    fi
+
+    echo "Running: ${cmd} logs -f --tail ${2:-100} ${__params[@]} | grep -iE --color=auto '(exception|fatal|error|warning|info|trigger_error)|$'"
+    ${cmd} logs -f --tail ${2:-100} ${__params[@]} | grep -iE --color=auto '(exception|fatal|error|warning|info|trigger_error)|$'
 }
 
 function dkr-reup {
-    read -q "reply?Are you sure you'd like to restart ${1:-everything}? "
+    read -q "reply?Are you sure you'd like to stop and start ${1:-everything}? "
     echo
 
     if [[ $reply =~ ^[Yy]$ ]]
@@ -43,12 +123,25 @@ function dkr-reup {
     fi
 }
 
+function dkr-restart {
+    read -q "reply?Are you sure you'd like to restart ${1:-everything}? "
+    echo
+
+    if [[ $reply =~ ^[Yy]$ ]]
+    then
+        docker-compose restart $1
+        dkr-logs $1
+    else
+        echo "Aborting!"
+    fi
+}
+
 function dkr-clean {
-    dkr-container-name ${1}
+    dkr-container-name $1
 
     dkr-down $1 && \
         docker-compose rm -f $1 && \
-        docker rmi "${__container}"
+        docker rmi "$__container"
 }
 
 function dkr-proxy {

--- a/home/.zsh/functions/docker.zsh
+++ b/home/.zsh/functions/docker.zsh
@@ -88,6 +88,10 @@ function dkr-up {
 }
 
 function dkr-bash {
+    if [[ -z $1 ]]; then
+        1=app
+    fi
+
     dkr-exec "$1" bash
 }
 

--- a/home/.zsh/functions/docker.zsh
+++ b/home/.zsh/functions/docker.zsh
@@ -10,6 +10,7 @@ function dkr-container-name {
     done
 
     # Replace the container name with the original if not a docker-compose project
+    __is_compose=false
     if [[ -f ./docker-compose.yml && "$__var" == "" ]]; then
         __is_compose=true
     elif [[ ! -f ./docker-compose.yml || "$(docker-compose ps | grep $__var)" == "" ]]; then
@@ -38,7 +39,7 @@ function dkr-exec {
         detachKeys=""
     fi
 
-    echo "Running: ${cmd} exec -e COLUMNS=\"`tput cols`\" -e LINES=\"`tput lines`\" ${detachKeys[@]} ${it} ${__params[@]}"
+    # echo "Running: ${cmd} exec -e COLUMNS=\"`tput cols`\" -e LINES=\"`tput lines`\" ${detachKeys[@]} ${it} ${__params[@]}"
     ${cmd} exec -e COLUMNS="`tput cols`" -e LINES="`tput lines`" ${detachKeys[@]} ${it} ${__params[@]}
 }
 
@@ -54,7 +55,7 @@ function dkr-run {
         detachKeys=""
     fi
 
-    echo "Running: ${cmd} run -e COLUMNS=\"`tput cols`\" -e LINES=\"`tput lines`\" ${detachKeys[@]} ${it} ${__params[@]}"
+    # echo "Running: ${cmd} run -e COLUMNS=\"`tput cols`\" -e LINES=\"`tput lines`\" ${detachKeys[@]} ${it} ${__params[@]}"
     ${cmd} run -e COLUMNS="`tput cols`" -e LINES="`tput lines`" ${detachKeys[@]} ${it} ${__params[@]}
 }
 
@@ -111,7 +112,7 @@ function dkr-logs {
         cmd="docker-compose"
     fi
 
-    echo "Running: ${cmd} logs -f --tail ${2:-100} ${__params[@]} | grep -iE --color=auto '(exception|fatal|error|warning|info|trigger_error)|$'"
+    # echo "Running: ${cmd} logs -f --tail ${2:-100} ${__params[@]} | grep -iE --color=auto '(exception|fatal|error|warning|info|trigger_error)|$'"
     ${cmd} logs -f --tail ${2:-100} ${__params[@]} | grep -iE --color=auto '(exception|fatal|error|warning|info|trigger_error)|$'
 }
 


### PR DESCRIPTION
This updates the helper commands for docker management to make them a
bit smarter. Instead of assuming docker-compose for some commands and
docker for others, we now try to figure out if the container you're
trying to execute against is docker-compose or docker -- and reacts
accordingly. This provides a seamless experience, allowing you to
dkr-logs the proxy or ssl container as well as containers in your
project.  In addition, you can dkr-zsh/bash in the same manner.

I've also added dkr-restart. dkr-reup stops and starts the container,
reloading any changes to docker-compose files. With dkr-restart, we just
issue a restart command which is **much** faster.

Lastly, I've made dkr-stats smarter. Previously, it showed the stats for
all running containers. While this is useful, it's overkill on systems
running many containers. Sometimes you just want to watch one container
-- and now you can.