### PR TITLE
docker: Remove ACME_CA_URI from ssl container

### DIFF
--- a/home/.zsh/functions/docker.zsh
+++ b/home/.zsh/functions/docker.zsh
@@ -177,7 +177,6 @@ function dkr-proxy {
 
     docker pull jrcs/letsencrypt-nginx-proxy-companion && \
         dkr-run --name ssl -d \
-            -e "ACME_CA_URI=https://acme-v01.api.letsencrypt.org/directory" \
             -v /var/run/docker.sock:/var/run/docker.sock:ro \
             -v ~/.config/nginx-proxy/certs:/etc/nginx/certs:rw \
             --volumes-from proxy \


### PR DESCRIPTION
The letsencrypt-nginx-proxy-companion has upgraded to v2 of the letsencrypt api and the previously defined URI is now invalid.