### PR TITLE
docker: Handle binary data in logs

### DIFF
--- a/home/.zsh/functions/docker.zsh
+++ b/home/.zsh/functions/docker.zsh
@@ -113,8 +113,8 @@ function dkr-logs {
         cmd="docker-compose"
     fi
 
-    # echo "Running: ${cmd} logs -f --tail ${2:-100} ${__params[@]} | grep -iE --color=auto '(exception|fatal|error|warning|info|trigger_error)|$'"
-    ${cmd} logs -f --tail ${2:-100} ${__params[@]} | grep -iE --color=auto '(exception|fatal|error|warning|info|trigger_error)|$'
+    # echo "Running: ${cmd} logs -f --tail ${2:-100} ${__params[@]} | grep -aiE --color=auto '(exception|fatal|error|warning|info|trigger_error)|$'"
+    ${cmd} logs -f --tail ${2:-100} ${__params[@]} | grep -aiE --color=auto '(exception|fatal|error|warning|info|trigger_error)|$'
 }
 
 function dkr-reup {


### PR DESCRIPTION
When running dkr-logs, the grep can cause issues without the -a flag.