### PR TITLE
zsh: Better autocomplete

### DIFF
--- a/home/.zsh/completion.zsh
+++ b/home/.zsh/completion.zsh
@@ -2,6 +2,7 @@ autoload -U compinit
 compinit
 
 zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
+zstyle ":completion:*:commands" rehash 1
 
 ## automatically decide when to page a list of completions
 LISTMAX=0


### PR DESCRIPTION
Summary:
If a new binary is created, the zsh autocomplete cache keeps it from
being seen in tab completion. We've enabled rehashing every time we do
tab completion to keep this from happening.